### PR TITLE
Remove docs project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] = Seq(
   cluster, clusterMetrics, clusterSharding, clusterTools,
   contrib,
   distributedData,
-  docs,
+  /*docs,*/
   multiNodeTestkit,
   osgi,
   persistence, persistenceQuery, persistenceShared, persistenceTck,
@@ -39,7 +39,7 @@ lazy val root = Project(
   base = file("."),
   aggregate = aggregatedProjects
 ).settings(rootSettings: _*)
- .settings(unidocRootIgnoreProjects := Seq(remoteTests, benchJmh, protobuf, akkaScalaNightly, docs))
+ .settings(unidocRootIgnoreProjects := Seq(remoteTests, benchJmh, protobuf, akkaScalaNightly/*, docs*/))
 
 lazy val actor = akkaModule("akka-actor")
 
@@ -51,7 +51,7 @@ lazy val agent = akkaModule("akka-agent")
 
 lazy val akkaScalaNightly = akkaModule("akka-scala-nightly")
   // remove dependencies that we have to build ourselves (Scala STM)
-  .aggregate(aggregatedProjects diff List[ProjectReference](agent, docs): _*)
+  .aggregate(aggregatedProjects diff List[ProjectReference](agent/*, docs*/): _*)
   .disablePlugins(ValidatePullRequest, MimaPlugin)
 
 lazy val benchJmh = akkaModule("akka-bench-jmh")
@@ -99,17 +99,17 @@ lazy val distributedData = akkaModule("akka-distributed-data")
   .dependsOn(cluster % "compile->compile;test->test;multi-jvm->multi-jvm")
   .configs(MultiJvm)
 
-lazy val docs = akkaModule("akka-docs")
-  .dependsOn(
-    actor, cluster, clusterMetrics, slf4j, agent, camel, osgi, persistenceTck, persistenceQuery, distributedData, stream,
-    clusterTools % "compile->compile;test->test",
-    testkit % "compile->compile;test->test",
-    remote % "compile->compile;test->test",
-    persistence % "compile->compile;provided->provided;test->test",
-    typed % "compile->compile;test->test",
-    typedTests % "compile->compile;test->test",
-    streamTestkit % "compile->compile;test->test"
-  )
+//lazy val docs = akkaModule("akka-docs")
+//  .dependsOn(
+//    actor, cluster, clusterMetrics, slf4j, agent, camel, osgi, persistenceTck, persistenceQuery, distributedData, stream,
+//    clusterTools % "compile->compile;test->test",
+//    testkit % "compile->compile;test->test",
+//    remote % "compile->compile;test->test",
+//    persistence % "compile->compile;provided->provided;test->test",
+//    typed % "compile->compile;test->test",
+//    typedTests % "compile->compile;test->test",
+//    streamTestkit % "compile->compile;test->test"
+//  )
 
 lazy val multiNodeTestkit = akkaModule("akka-multi-node-testkit")
   .dependsOn(remote, testkit)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -38,7 +38,7 @@ addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.0")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
 
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.3")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.39")
 
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.2")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -38,7 +38,7 @@ addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.0")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
 
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.39")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.3")
 
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.2")
 


### PR DESCRIPTION
We are getting the following exceptions in our tests

```
17:05:56     sbt.ResolveException: unresolved dependency: com.lightbend.akka#paradox-theme-akka;0.3: not found
17:05:56       at sbt.IvyActions$.sbt$IvyActions$$resolve(IvyActions.scala:313)
17:05:56       at sbt.IvyActions$$anonfun$updateEither$1.apply(IvyActions.scala:191)
17:05:56       at sbt.IvyActions$$anonfun$updateEither$1.apply(IvyActions.scala:168)
17:05:56       at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:156)
17:05:56       at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:156)
17:05:56       at sbt.IvySbt$$anonfun$withIvy$1.apply(Ivy.scala:133)
17:05:56       at sbt.IvySbt.sbt$IvySbt$$action$1(Ivy.scala:57)
17:05:56       at sbt.IvySbt$$anon$4.call(Ivy.scala:65)
17:05:56       at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:113)
17:05:56       at xsbt.boot.Locks$GlobalLock.withChannelRetries$1(Locks.scala:91)
17:05:56       at xsbt.boot.Locks$GlobalLock.$anonfun$withFileLock$1(Locks.scala:119)
17:05:56       at xsbt.boot.Using$.withResource(Using.scala:12)
17:05:56       at xsbt.boot.Using$.apply(Using.scala:9)
17:05:56       at xsbt.boot.Locks$GlobalLock.withFileLock(Locks.scala:119)
17:05:56       at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:71)
17:05:56       at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:59)
17:05:56       at xsbt.boot.Locks$.apply0(Locks.scala:47)
17:05:56       at xsbt.boot.Locks$.apply(Locks.scala:36)
17:05:56       at sbt.IvySbt.withDefaultLogger(Ivy.scala:65)
17:05:56       at sbt.IvySbt.withIvy(Ivy.scala:128)
17:05:56       at sbt.IvySbt.withIvy(Ivy.scala:125)
17:05:56       at sbt.IvySbt$Module.withModule(Ivy.scala:156)
17:05:56       at sbt.IvyActions$.updateEither(IvyActions.scala:168)
17:05:56       at sbt.Classpaths$$anonfun$sbt$Classpaths$$work$1$1.apply(Defaults.scala:1488)
17:05:56       at sbt.Classpaths$$anonfun$sbt$Classpaths$$work$1$1.apply(Defaults.scala:1484)
17:05:56       at sbt.Classpaths$$anonfun$doWork$1$1$$anonfun$121.apply(Defaults.scala:1519)
17:05:56       at sbt.Classpaths$$anonfun$doWork$1$1$$anonfun$121.apply(Defaults.scala:1517)
17:05:56       at sbt.Tracked$$anonfun$lastOutput$1.apply(Tracked.scala:37)
17:05:56       at sbt.Classpaths$$anonfun$doWork$1$1.apply(Defaults.scala:1522)
17:05:56       at sbt.Classpaths$$anonfun$doWork$1$1.apply(Defaults.scala:1516)
17:05:56       at sbt.Tracked$$anonfun$inputChanged$1.apply(Tracked.scala:60)
17:05:56       at sbt.Classpaths$.cachedUpdate(Defaults.scala:1539)
17:05:56       at sbt.Classpaths$$anonfun$updateTask$1.apply(Defaults.scala:1466)
17:05:56       at sbt.Classpaths$$anonfun$updateTask$1.apply(Defaults.scala:1418)
17:05:56       at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
17:05:56       at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
17:05:56       at sbt.std.Transform$$anon$4.work(System.scala:63)
17:05:56       at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
17:05:56       at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
17:05:56       at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
17:05:56       at sbt.Execute.work(Execute.scala:237)
17:05:56       at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
17:05:56       at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
17:05:56       at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
17:05:56       at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
17:05:56       at java.util.concurrent.FutureTask.run(FutureTask.java:266)
17:05:56       at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
17:05:56       at java.util.concurrent.FutureTask.run(FutureTask.java:266)
17:05:56       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
17:05:56       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
17:05:56       at java.lang.Thread.run(Thread.java:750)
17:05:56     [error] (akka-docs/*:update) sbt.ResolveException: unresolved dependency: com.lightbend.akka#paradox-theme-akka;0.3: not found
17:05:56     [error] Total time: 238 s, completed Aug 18, 2024 5:05:56 PM
```

It happens because JCenter is not available anymore. Due to that `addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.3")` plugin is no longer available. We also can't use a newer version that is available in Maven Central because it only compiled for Scala 2.12 and not 2.10. Since our tests are not interested in docs, I think it's should be fine to comment out `docs` project.