### PR TITLE
Use Jenkins repository resolver instead of JCenter

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 resolvers += Classpaths.typesafeResolver
 
-// need this to resolve http://jcenter.bintray.com/org/jenkins-ci/jenkins/1.26/
+// need this to resolve https://repo.jenkins-ci.org/public/org/jenkins-ci/jenkins/1.26/
 // which is used by plugin "org.kohsuke" % "github-api" % "1.68"
-resolvers += "Bintray Jcenter" at "https://jcenter.bintray.com/"
+resolvers += "Jenkins Public Repository" at "https://repo.jenkins-ci.org/public/"
 
 // these comment markers are for including code into the docs
 //#sbt-multi-jvm


### PR DESCRIPTION
Mirco did the same change concurrently in his fork: https://github.com/dotta/akka/commit/a905283a05ef5353970ad03af16eccf39b4a6da3. We've switched to his fork and will see whether the change fixes the problem or not. This will ensure that all forks are in sync. If the change will help, after merging it, we probably need to go back to using this fork. Otherwise, everyone looking at the `git log` will have questions about why we move from one to another and what are the differences.